### PR TITLE
Convert pressure display from mb to inHg

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -641,7 +641,7 @@ function processObservations(props) {
   result.windDir    = degreesToCardinal(props.windDirection && props.windDirection.value);
   result.windSpeed  = nwsKmhToMph(props.windSpeed);
   result.windGust   = nwsKmhToMph(props.windGust);
-  result.pressure   = nwsPaToMb(props.barometricPressure);
+  result.pressure   = nwsPaToInHg(props.barometricPressure);
   result.visibility = nwsMToMi(props.visibility);
   result.humidity   = props.relativeHumidity ? Math.round(props.relativeHumidity.value) : null;
   result.condition  = props.textDescription  || null;
@@ -1200,7 +1200,7 @@ function buildConditionsPanelHtml(wx, apparent, daily, alerts, aqi,
     ? wx.humidity + '%' + (wx.dewpoint !== null ? ' · Dew ' + wx.dewpoint + '°F' : '')
     : '--';
 
-  const pressVal  = wx.pressure   !== null ? wx.pressure   + ' mb' : '--';
+  const pressVal  = wx.pressure   !== null ? wx.pressure   + ' inHg' : '--';
   const visVal    = wx.visibility !== null ? wx.visibility + ' mi' : '--';
 
   // Hi/Lo from the daily forecast periods (first daytime = high, first night = low).
@@ -1824,10 +1824,11 @@ function nwsKmhToMph(valueObj) {
   return Math.round(valueObj.value * 0.6214);
 }
 
-// Converts a NWS pressure value object (Pa) to mb (hPa), rounded to integer.
-function nwsPaToMb(valueObj) {
+// Converts a NWS pressure value object (Pa) to inHg, rounded to 2 decimal places.
+// 1 inHg = 3386.389 Pa
+function nwsPaToInHg(valueObj) {
   if (!valueObj || valueObj.value === null || valueObj.value === undefined) return null;
-  return Math.round(valueObj.value / 100);
+  return Math.round(valueObj.value / 3386.389 * 100) / 100;
 }
 
 // Converts a NWS visibility value object (metres) to miles, one decimal place.


### PR DESCRIPTION
## Summary

- Replace `nwsPaToMb` (Pa → hPa, integer) with `nwsPaToInHg` (Pa → inHg, 2 decimal places) using the conversion factor 1 inHg = 3386.389 Pa
- Update the call site in `processObservations` to use the new function
- Update the display label from `' mb'` to `' inHg'`

## Test plan

- [ ] Verify pressure readings display with `inHg` unit (e.g. `29.92 inHg`)
- [ ] Verify null/missing pressure still shows `--`
- [ ] Confirm no other code was modified

https://claude.ai/code/session_0177vqouhma7szotseZPMeQN