### PR TITLE
Filter today from daily forecast; bump FORECAST_DAYS to 4

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ const NWS_ALERT_ZONE = 'NDZ039';    // Cass County, ND
 const NWS_STATION    = 'KFAR';      // Fargo Hector International Airport
 
 // Forecast display
-const FORECAST_DAYS  = 3;    // number of days in the 3-day forecast
+const FORECAST_DAYS  = 4;    // fetch 4 days so tomorrow is day 1 after today is filtered out
 const HOURLY_COUNT   = 12;   // number of hourly slots in the bottom strip
 
 // Radar animation (client-side)
@@ -735,8 +735,14 @@ function buildDailyForecast(periods, count) {
     }
   }
 
-  // Return the next `count` calendar dates that have forecast data.
-  return Object.values(map).slice(0, count);
+  // Drop today's entry so the forecast starts from tomorrow — today's
+  // conditions are already shown in the current conditions panel.
+  // Fetch one extra day (FORECAST_DAYS = 4) so that after filtering
+  // today out, exactly 3 future days remain.
+  const todayStr = toLocalDateStr(new Date());
+  return Object.values(map).filter(function(d) {
+    return d.dateStr !== todayStr;
+  }).slice(0, count);
 }
 
 // Builds the hourly strip slot array from NWS hourly forecast periods.


### PR DESCRIPTION
## Summary

- Increase `FORECAST_DAYS` from 3 to 4 so an extra day is fetched from the API
- Filter today's date out of the daily forecast array before returning it, so the forecast panel shows only future days (tomorrow through day 3)
- Today's conditions are already displayed in the current conditions panel, so excluding today keeps the forecast panel strictly forward-looking

## Test plan

- [ ] Verify the forecast panel shows exactly 3 days, all of which are tomorrow or later
- [ ] Confirm today's date does not appear as a forecast card
- [ ] Check that the current conditions panel is unaffected
- [ ] Test around midnight to ensure the date boundary is handled correctly

https://claude.ai/code/session_012kvWgX7N3Kzd92nQxY9Pcp