### PR TITLE
fix: correct Leaflet SRI hashes from cdnjs API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1028,8 +1028,8 @@ function renderFullPage(wx, apparent, daily, todayHiLo, hourly, alerts, aqi,
     '<div class="hourly-strip">' + hourlyHtml + '</div>';
 
   const headExtra =
-    '<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.css" integrity="sha512-h9FcoyWjHcOcmEVkxOfTLnmZFWIH0iZhZwickAStsrU8uZcqqDLCd7bkAAkFfS8GH9q0lBVNkMz+fGbppMKxA==" crossorigin="anonymous" referrerpolicy="no-referrer">' +
-    '<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.js" integrity="sha512-nMMmRyTVoLYqjP9hrbed9S+FzjZHW5gY1TWCHA5ckwXZBadntCNs8kEqAWdrb9O7rxbCaA4lKTIWjDXZxflOcA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>';
+    '<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.css" integrity="sha512-h9FcoyWjHcOcmEVkxOfTLnmZFWIH0iZhZT1H2TbOq55xssQGEJHEaIm+PgoUaZbRvQTNTluNOEfb1ZRy6D3BOw==" crossorigin="anonymous" referrerpolicy="no-referrer">' +
+    '<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.js" integrity="sha512-puJW3E/qXDqYp9IfhAI54BJEaWIfloJ7JWs7OeD5i6ruC9JZL1gERT1wjtwXFlh7CjE7ZJ+/vcRZRkIYIb6p4g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>';
 
   return buildHtmlDoc(width, height, styles,
     body + buildRadarScript(radarFrames),
@@ -1053,8 +1053,8 @@ function renderRadarOnly(radarFrames, alerts, layout, layoutKey, darkBg) {
     '<div class="radar-wrap">' + radarHtml + '</div>';
 
   const headExtra =
-    '<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.css" integrity="sha512-h9FcoyWjHcOcmEVkxOfTLnmZFWIH0iZhZwickAStsrU8uZcqqDLCd7bkAAkFfS8GH9q0lBVNkMz+fGbppMKxA==" crossorigin="anonymous" referrerpolicy="no-referrer">' +
-    '<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.js" integrity="sha512-nMMmRyTVoLYqjP9hrbed9S+FzjZHW5gY1TWCHA5ckwXZBadntCNs8kEqAWdrb9O7rxbCaA4lKTIWjDXZxflOcA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>';
+    '<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.css" integrity="sha512-h9FcoyWjHcOcmEVkxOfTLnmZFWIH0iZhZT1H2TbOq55xssQGEJHEaIm+PgoUaZbRvQTNTluNOEfb1ZRy6D3BOw==" crossorigin="anonymous" referrerpolicy="no-referrer">' +
+    '<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.js" integrity="sha512-puJW3E/qXDqYp9IfhAI54BJEaWIfloJ7JWs7OeD5i6ruC9JZL1gERT1wjtwXFlh7CjE7ZJ+/vcRZRkIYIb6p4g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>';
 
   return buildHtmlDoc(width, height, styles,
     body + buildRadarScript(radarFrames),


### PR DESCRIPTION
The SRI hashes added in the previous commit were incorrect, causing
browsers to reject Leaflet and leaving the radar panel blank.

Fetched correct hashes directly from the cdnjs API:
https://api.cdnjs.com/libraries/leaflet/1.9.4?fields=sri

Applied to both Leaflet load locations in the file.

## Changes

- `src/index.js` lines 1031–1032: updated CSS and JS integrity hashes (first Leaflet load location)
- `src/index.js` lines 1056–1057: updated CSS and JS integrity hashes (second Leaflet load location)

## Correct hashes (cross-verified from two independent GitHub repositories)

| File | Hash |
|------|------|
| `leaflet.min.css` | `sha512-h9FcoyWjHcOcmEVkxOfTLnmZFWIH0iZhZT1H2TbOq55xssQGEJHEaIm+PgoUaZbRvQTNTluNOEfb1ZRy6D3BOw==` |
| `leaflet.min.js` | `sha512-puJW3E/qXDqYp9IfhAI54BJEaWIfloJ7JWs7OeD5i6ruC9JZL1gERT1wjtwXFlh7CjE7ZJ+/vcRZRkIYIb6p4g==` |