### PR TITLE
fix: filter implausible temperatures in getDailyHiLo

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -125,6 +125,14 @@ const ERROR_RETRY_SECONDS = 60;
 // and displayed silently as if current. Set to 0 to disable fallback.
 const WIND_STALE_MAX_HOURS = 2;
 
+// Sanity bounds for forecast high and low temperatures (°F).
+// NWS occasionally returns erroneous sentinel values (e.g. -100°F).
+// Any temperature outside this range is treated as missing data.
+// Fargo ND all-time records: -43°F (1996) to 114°F (1936).
+// Bounds are wider than records to allow for future extremes.
+const TEMP_MIN_PLAUSIBLE_F = -80;
+const TEMP_MAX_PLAUSIBLE_F = 140;
+
 
 // =============================================================================
 // SVG WEATHER ICONS — precomputed at module load (zero cost per request)
@@ -966,8 +974,18 @@ function getDailyHiLo(periods) {
   if (!periods) return { high: null, low: null };
   let high = null, low = null;
   for (let i = 0; i < Math.min(periods.length, 6); i++) {
-    if (periods[i].isDaytime  && high === null) high = periods[i].temperature;
-    if (!periods[i].isDaytime && low  === null) low  = periods[i].temperature;
+    var hiTemp = periods[i].temperature;
+    var loTemp = periods[i].temperature;
+    if (periods[i].isDaytime  && high === null &&
+        hiTemp !== null && hiTemp !== undefined &&
+        hiTemp >= TEMP_MIN_PLAUSIBLE_F && hiTemp <= TEMP_MAX_PLAUSIBLE_F) {
+      high = hiTemp;
+    }
+    if (!periods[i].isDaytime && low === null &&
+        loTemp !== null && loTemp !== undefined &&
+        loTemp >= TEMP_MIN_PLAUSIBLE_F && loTemp <= TEMP_MAX_PLAUSIBLE_F) {
+      low = loTemp;
+    }
     if (high !== null && low !== null) break;
   }
   return { high, low };


### PR DESCRIPTION
## Summary

- Added `TEMP_MIN_PLAUSIBLE_F` (-80) and `TEMP_MAX_PLAUSIBLE_F` (140) constants to the configuration section
- Updated `getDailyHiLo` to skip any temperature value outside those bounds, treating it as missing data
- The loop continues scanning subsequent periods for a valid value, so a single erroneous sentinel won't suppress the real forecast high/low

## Background

NWS occasionally returns erroneous sentinel values such as -100°F for forecast high/low temperatures. `getDailyHiLo` previously accepted the first value it found without any sanity check.

Bounds are wider than Fargo ND all-time records (-43°F / 114°F) to allow for genuine extremes while still catching sentinel values.

Reminder: close weather-display issue #45 once verified.

## Test plan

- [ ] Verify normal forecasts (values within bounds) still display correct hi/lo
- [ ] Simulate a -100°F period value and confirm it is skipped; next valid period's value is used instead
- [ ] Confirm `null` temperature values are also safely skipped
- [ ] Check that both daytime high and nighttime low paths are exercised

https://claude.ai/code/session_018ThZQCKbrNmMGU9qFBVos6

---
_Generated by [Claude Code](https://claude.ai/code/session_018ThZQCKbrNmMGU9qFBVos6)_