### PR TITLE
fix: use ICON_SIZE_SM constant for sunrise, sunset, and raindrop SVG sizes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -275,7 +275,7 @@ const WX_LG = _buildIconSet(ICON_SIZE_LG);
 const WX_SM = _buildIconSet(ICON_SIZE_SM);
 
 const WX_SVG_SUNRISE =
-  '<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 18 18" style="display:inline-block;vertical-align:middle;">' +
+  '<svg xmlns="http://www.w3.org/2000/svg" width="' + ICON_SIZE_SM + '" height="' + ICON_SIZE_SM + '" viewBox="0 0 18 18" style="display:inline-block;vertical-align:middle;">' +
   '<circle cx="6" cy="9" r="3" fill="#f0c040"/>' +
   '<line x1="6" y1="4.5" x2="6" y2="6" stroke="#f0c040" stroke-width="1.4" stroke-linecap="round"/>' +
   '<line x1="6" y1="12" x2="6" y2="13.5" stroke="#f0c040" stroke-width="1.4" stroke-linecap="round"/>' +
@@ -289,7 +289,7 @@ const WX_SVG_SUNRISE =
   '</svg>';
 
 const WX_SVG_SUNSET =
-  '<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 18 18" style="display:inline-block;vertical-align:middle;">' +
+  '<svg xmlns="http://www.w3.org/2000/svg" width="' + ICON_SIZE_SM + '" height="' + ICON_SIZE_SM + '" viewBox="0 0 18 18" style="display:inline-block;vertical-align:middle;">' +
   '<circle cx="6" cy="9" r="3" fill="#f0c040"/>' +
   '<line x1="6" y1="4.5" x2="6" y2="6" stroke="#f0c040" stroke-width="1.4" stroke-linecap="round"/>' +
   '<line x1="6" y1="12" x2="6" y2="13.5" stroke="#f0c040" stroke-width="1.4" stroke-linecap="round"/>' +
@@ -303,7 +303,7 @@ const WX_SVG_SUNSET =
   '</svg>';
 
 const WX_SVG_DROP =
-  '<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 12 12" style="display:inline-block;vertical-align:middle;">' +
+  '<svg xmlns="http://www.w3.org/2000/svg" width="' + ICON_SIZE_SM + '" height="' + ICON_SIZE_SM + '" viewBox="0 0 12 12" style="display:inline-block;vertical-align:middle;">' +
   '<path d="M6 1 C6 1 2 6 2 8.5 C2 10.5 3.8 12 6 12 C8.2 12 10 10.5 10 8.5 C10 6 6 1 6 1 Z" fill="#4db8ff"/>' +
   '</svg>';
 


### PR DESCRIPTION
WX_SVG_SUNRISE, WX_SVG_SUNSET, and WX_SVG_DROP had hardcoded
width/height values (22px and 15px respectively) instead of using
the existing ICON_SIZE_SM constant like all other weather icons.

Updated all three to use ICON_SIZE_SM for both width and height.
viewBox values are unchanged — they define the internal coordinate
system and are independent of the rendered size.

Reminder: close weather-display issue #46 once verified on hardware.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eo5MALNrn7GpCnohv9u7mZ)_