### PR TITLE
fix: use smaller raindrop icon in hourly strip

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -307,6 +307,11 @@ const WX_SVG_DROP =
   '<path d="M6 1 C6 1 2 6 2 8.5 C2 10.5 3.8 12 6 12 C8.2 12 10 10.5 10 8.5 C10 6 6 1 6 1 Z" fill="#4db8ff"/>' +
   '</svg>';
 
+const WX_SVG_DROP_SM =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 12 12" style="display:inline-block;vertical-align:middle;">' +
+  '<path d="M6 1 C6 1 2 6 2 8.5 C2 10.5 3.8 12 6 12 C8.2 12 10 10.5 10 8.5 C10 6 6 1 6 1 Z" fill="#4db8ff"/>' +
+  '</svg>';
+
 // Maps an NWS shortForecast string to the appropriate precomputed SVG icon.
 // Checks are case-insensitive and ordered most-specific to least-specific to
 // prevent broad matches (e.g. "rain") from shadowing specific ones (e.g. "freezing rain").
@@ -1561,7 +1566,7 @@ function buildHourlyStripHtml(hourly, width, stripH, scale) {
           escapeHtml(slot.temp !== null ? slot.temp + '°' : '--') +
         '</div>' +
         (precip
-          ? '<div class="hour-precip" style="font-size:' + precipFontSize + 'px;">' + WX_SVG_DROP + ' ' +
+          ? '<div class="hour-precip" style="font-size:' + precipFontSize + 'px;">' + WX_SVG_DROP_SM + ' ' +
               escapeHtml(precip) + '</div>'
           : '<div class="hour-precip"></div>'
         ) +


### PR DESCRIPTION
## Summary

- Added `WX_SVG_DROP_SM` constant at 14px fixed size for use in the compact hourly strip
- Updated `buildHourlyStripHtml` to use `WX_SVG_DROP_SM` instead of `WX_SVG_DROP`
- The 3-day forecast rows continue to use `WX_SVG_DROP` at `ICON_SIZE_SM` (26px) — unchanged

## Details

`WX_SVG_DROP` at `ICON_SIZE_SM` (26px) is too large for the compact hourly strip, causing the drop icon to be clipped. `WX_SVG_DROP_SM` uses the same path/colour but a fixed 14px size appropriate for inline use next to small font labels.

## Test plan

- [ ] Load `?layout=full` and confirm hourly strip precip slots show a small (14px) raindrop icon
- [ ] Confirm 3-day forecast rows still show the larger (26px) raindrop icon
- [ ] Verify on hardware (close issue #46 once confirmed)

https://claude.ai/code/session_018EfRdbiW1ppihSpDMvDuHq

---
_Generated by [Claude Code](https://claude.ai/code/session_018EfRdbiW1ppihSpDMvDuHq)_