### PR TITLE
feat: two-column grid layout for hourly strip cards

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1875,15 +1875,34 @@ function baseStyles(width, height, useSolidBg) {
       'border-top:1px solid ' + BORDER_STRONG + ';background:' + CARD_BASE + ';flex-shrink:0;' +
     '}' +
     '.hour-card{' +
-      'flex:1;display:flex;flex-direction:column;align-items:center;' +
-      'justify-content:center;gap:3px;' +
-      'border-right:1px solid ' + BORDER_SUBTLE + ';padding:4px 0;' +
+      'flex:1;display:grid;' +
+      'grid-template-columns:1fr 1fr;' +
+      'grid-template-rows:1fr 1fr;' +
+      'border-right:1px solid ' + BORDER_SUBTLE + ';' +
+      'padding:4px 6px;' +
+      'gap:2px;' +
     '}' +
     '.hour-card:last-child{border-right:none;}' +
-    '.hour-time{color:' + TEXT_SECONDARY + ';text-transform:uppercase;letter-spacing:.04em;}' +
-    '.hour-icon{flex-shrink:0;}' +
-    '.hour-temp{color:#fff;font-weight:600;}' +
-    '.hour-precip{color:#4db8ff;}' +
+    '.hour-time{' +
+      'grid-column:1;grid-row:1;' +
+      'color:' + TEXT_SECONDARY + ';' +
+      'text-transform:uppercase;letter-spacing:.04em;' +
+      'align-self:end;font-size:inherit;' +
+    '}' +
+    '.hour-icon{' +
+      'grid-column:2;grid-row:1;' +
+      'display:flex;align-items:flex-end;justify-content:flex-end;' +
+    '}' +
+    '.hour-temp{' +
+      'grid-column:1;grid-row:2;' +
+      'color:#fff;font-weight:600;' +
+      'align-self:start;' +
+    '}' +
+    '.hour-precip{' +
+      'grid-column:2;grid-row:2;' +
+      'color:#4db8ff;' +
+      'display:flex;align-items:flex-start;justify-content:flex-end;' +
+    '}' +
     '.hourly-empty{flex:1;display:flex;align-items:center;justify-content:center;' +
       'color:' + TEXT_TERTIARY + ';font-size:12px;}'
   );


### PR DESCRIPTION
## Summary

- Replaced vertical flex stack in hourly strip cards with a 2×2 CSS grid layout
- Each card now uses: time (top-left), icon (top-right), temperature (bottom-left), precipitation (bottom-right)
- No HTML structure changes needed — grid placement is controlled entirely via `grid-column`/`grid-row` on the child elements

## Layout

```
┌──────────┬──────────┐
│  time    │   icon   │
├──────────┼──────────┤
│  temp    │  precip  │
└──────────┴──────────┘
```

## Test plan

- [ ] Verify hourly strip renders with 12 cards in wide/full layout
- [ ] Confirm time label appears top-left, icon top-right, temp bottom-left, precip bottom-right in each card
- [ ] Confirm cards with no precip data show an empty bottom-right cell (no layout breakage)
- [ ] Confirm strip height is unchanged from before
- [ ] Check card borders and last-child border-right:none still apply correctly

https://claude.ai/code/session_01PM4BGY3tJiBWSDhtAS963i

---
_Generated by [Claude Code](https://claude.ai/code/session_01PM4BGY3tJiBWSDhtAS963i)_