### PR TITLE
fix: simplify hourly card grid alignment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1876,32 +1876,33 @@ function baseStyles(width, height, useSolidBg) {
     '}' +
     '.hour-card{' +
       'flex:1;display:grid;' +
-      'grid-template-columns:1fr auto;' +
+      'grid-template-columns:auto auto;' +
       'grid-template-rows:1fr 1fr;' +
+      'justify-content:space-around;' +
+      'align-items:center;' +
       'border-right:1px solid ' + BORDER_SUBTLE + ';' +
-      'padding:4px 6px;' +
-      'gap:2px;' +
+      'padding:4px 4px;' +
     '}' +
     '.hour-card:last-child{border-right:none;}' +
     '.hour-time{' +
       'grid-column:1;grid-row:1;' +
       'color:' + TEXT_SECONDARY + ';' +
       'text-transform:uppercase;letter-spacing:.04em;' +
-      'align-self:end;font-size:inherit;' +
+      'align-self:center;justify-self:center;' +
     '}' +
     '.hour-icon{' +
       'grid-column:2;grid-row:1;' +
-      'display:flex;align-items:flex-end;justify-content:flex-end;' +
+      'display:flex;align-items:center;justify-content:center;' +
     '}' +
     '.hour-temp{' +
       'grid-column:1;grid-row:2;' +
       'color:#fff;font-weight:600;' +
-      'align-self:start;' +
+      'align-self:center;justify-self:center;' +
     '}' +
     '.hour-precip{' +
       'grid-column:2;grid-row:2;' +
       'color:#4db8ff;' +
-      'display:flex;align-items:flex-start;justify-content:flex-end;' +
+      'display:flex;align-items:center;justify-content:center;' +
     '}' +
     '.hourly-empty{flex:1;display:flex;align-items:center;justify-content:center;' +
       'color:' + TEXT_TERTIARY + ';font-size:12px;}'


### PR DESCRIPTION
Two CSS fixes for the hourly strip cards:

1. Changed `grid-template-columns` from `1fr auto` to `auto auto` with `justify-content:space-around`. Left column no longer expands to fill all card space — both columns size to content and distribute evenly within the card.

2. Simplified alignment to `align-items:center` on the card and all children. Removed conflicting `align-self:end/start` overrides that caused slight vertical misalignment between columns.

## Changes
- `.hour-card`: `grid-template-columns:auto auto`, added `justify-content:space-around` and `align-items:center`, removed `gap:2px`, `padding:4px 6px` → `4px 4px`
- `.hour-time`: `align-self:end` → `align-self:center;justify-self:center`
- `.hour-icon`: `align-items:flex-end;justify-content:flex-end` → `align-items:center;justify-content:center`
- `.hour-temp`: `align-self:start` → `align-self:center;justify-self:center`
- `.hour-precip`: `align-items:flex-start;justify-content:flex-end` → `align-items:center;justify-content:center`

CSS-only fix — no HTML changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuHcX32E62kpsE2k7gcxsA)_