### PR TITLE
fix: hide Current Conditions header on non-full layouts

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1531,7 +1531,7 @@ function buildConditionsPanelHtml(wx, apparent, daily, todayHiLo, alerts, aqi,
     '<div class="forecast">' + forecastRowsHtml + '</div>';
 
   return (
-    sectionHeader('Current Conditions') +
+    (isFull ? sectionHeader('Current Conditions') : '') +
     currentHtml +
     statsHtml   +
     sunHtml     +


### PR DESCRIPTION
The Current Conditions section header is redundant on wide/split/tri
layouts because the display hardware already shows a title banner.
Only the full layout now renders the header.

The 3-Day Forecast header is unchanged — it remains on all layouts.
The .sec-hdr CSS (ACCENT_COLOR background) is unchanged.

Reminder: close weather-display issue #48 once verified on hardware.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nb2XxRrp6vP5dXyMfWePWh)_