### PR TITLE
fix: add legend, progress bar, and timestamp to radar image mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1898,7 +1898,21 @@ function buildRadarImageHtml(radarFrames) {
         + 'transition:opacity 0.1s linear;" alt=""/>';
   }
 
-  html += '</div>';
+  html +=
+    '<div class="radar-legend">' +
+      '<div class="legend-title">dBZ</div>' +
+      '<div class="legend-bar"></div>' +
+      '<div class="legend-labels">' +
+        '<span>5</span><span>30</span><span>50</span><span>75</span>' +
+      '</div>' +
+    '</div>' +
+    '<div class="radar-stamp">' +
+      'RADAR · <span id="radar-stamp-time">--:-- --</span> CDT' +
+    '</div>' +
+    '<div class="loop-bar">' +
+      '<div id="radar-progress" class="loop-bar-fill"></div>' +
+    '</div>' +
+    '</div>';
 
   // Animation script
   html +=


### PR DESCRIPTION
## Summary

- `buildRadarImageHtml` was missing the legend, progress bar, and radar timestamp overlay elements that exist in `buildRadarPanelHtml` for Leaflet mode
- The animation script already referenced `radar-progress` and `radar-stamp-time` but those elements were never added to the DOM in image mode
- Added the same overlay elements to `buildRadarImageHtml` so image mode visually matches Leaflet mode

## Details

The three added overlays match the structure used by `buildRadarPanelHtml`:
- **Legend** — `<div class="radar-legend">` with `dBZ` title, color bar, and labels (5 / 30 / 50 / 75)
- **Timestamp** — `<div class="radar-stamp">` with `<span id="radar-stamp-time">` (already updated by the animation loop)
- **Progress bar** — `<div class="loop-bar">` / `<div id="radar-progress" class="loop-bar-fill">` (already updated by the animation loop)

Note: transparent radar frames over the base map with no precipitation in the area is correct behavior — not a bug.

## Test plan

- [ ] Load page with `RADAR_MODE = 'image'` and confirm legend, timestamp, and progress bar are visible
- [ ] Confirm progress bar animates as frames cycle
- [ ] Confirm timestamp updates each frame
- [ ] Confirm Leaflet mode (`RADAR_MODE = 'leaflet'`) is unaffected

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1fbyFrMp91XSHrSyVfGL6)_