### PR TITLE
fix: move forecast alert badge below precip and temp

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1706,17 +1706,21 @@ function buildConditionsPanelHtml(wx, apparent, daily, todayHiLo, alerts, aqi,
             : ''
           ) +
         '</div>' +
-        (precip
-          ? '<div class="fc-precip" style="font-size:' + fcDescFont + 'px;">' + WX_SVG_DROP + ' ' +
-              escapeHtml(precip) + '</div>'
-          : '<div class="fc-precip"></div>'
-        ) +
-        '<div class="fc-temp" style="font-size:' + fcTempFont + 'px;">' +
-          escapeHtml(hi) +
-          '<span class="fc-sep">/</span>' +
-          escapeHtml(lo) +
+        '<div class="fc-right">' +
+          '<div class="fc-right-top">' +
+            (precip
+              ? '<div class="fc-precip" style="font-size:' + fcDescFont + 'px;">' + WX_SVG_DROP + ' ' +
+                  escapeHtml(precip) + '</div>'
+              : '<div class="fc-precip"></div>'
+            ) +
+            '<div class="fc-temp" style="font-size:' + fcTempFont + 'px;">' +
+              escapeHtml(hi) +
+              '<span class="fc-sep">/</span>' +
+              escapeHtml(lo) +
+            '</div>' +
+          '</div>' +
+          (badgeHtml ? '<div class="fc-badge">' + badgeHtml + '</div>' : '') +
         '</div>' +
-        (badgeHtml ? '<div class="fc-badge">' + badgeHtml + '</div>' : '') +
       '</div>';
   }
 
@@ -2159,7 +2163,7 @@ function baseStyles(width, height, useSolidBg) {
     '.forecast{flex:1;display:flex;flex-direction:column;min-height:0;}' +
     '.fc-row{' +
       'flex:1;display:grid;' +
-      'grid-template-columns:50px auto 1fr auto auto auto;' +
+      'grid-template-columns:50px auto 1fr auto;' +
       'align-items:center;gap:6px;' +
       'padding:0 10px;' +
       'border-bottom:1px solid ' + BORDER_SUBTLE + ';min-height:0;' +
@@ -2182,6 +2186,12 @@ function baseStyles(width, height, useSolidBg) {
     '.fc-temp{color:' + TEXT_PRIMARY + ';font-weight:600;white-space:nowrap;text-align:right;}' +
     '.fc-sep{color:' + TEXT_TERTIARY + ';margin:0 2px;}' +
     '.fc-badge{white-space:nowrap;}' +
+    '.fc-right{' +
+      'display:flex;flex-direction:column;align-items:flex-end;gap:3px;' +
+    '}' +
+    '.fc-right-top{' +
+      'display:flex;flex-direction:row;align-items:center;gap:6px;' +
+    '}' +
     '.alert-badge{display:inline-block;padding:1px 5px;border-radius:3px;' +
       'font-weight:700;letter-spacing:.04em;}' +
     '.badge-warning {background:#cc2222;color:#fff;}' +


### PR DESCRIPTION
## Summary

- The future alert badge was rendering in a 6th grid column beside the temperature, making alerted rows feel crowded
- Wraps the right side of each forecast row in a new `fc-right` flex column container
- `fc-right-top` holds precip + temp side-by-side (unchanged visually)
- `fc-badge` sits below them, right-aligned
- Grid reduced from 6 to 4 columns: `day | icon | desc | fc-right`
- Rows without a badge are unaffected

## Test plan

- [ ] Load the display with an active future alert — confirm badge appears below the precip/temp pair, right-aligned
- [ ] Load without any future alerts — confirm forecast rows look identical to before
- [ ] Check all three layout variants (wide, full, split/conditions) for correct row proportions
- [ ] Verify no horizontal overflow or clipping on narrow layouts

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEBsmQdEuWo78wdLRHkwMF)_