### PR TITLE
fix: accept HEAD requests for UptimeRobot health monitoring

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -361,9 +361,13 @@ function getConditionIcon(shortForecast, iconSet) {
 export default {
   async fetch(request, env) {
 
-    // Reject non-GET requests with a generic error to reduce attack surface.
-    if (request.method !== 'GET') {
-      return new Response('Method not allowed', { status: 405 });
+    // Allow GET and HEAD (HEAD is used by UptimeRobot health monitoring).
+    // All other methods are rejected to reduce attack surface.
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      return new Response('Method not allowed', {
+        status: 405,
+        headers: { 'Allow': 'GET, HEAD' },
+      });
     }
 
     // Parse and validate URL parameters before the try block so the error
@@ -433,10 +437,12 @@ export default {
         }
       }
 
-      return new Response(
+      const healthBody =
         'status: ' + healthStatus + '\n' +
         'worker: weather-display\n' +
-        details.join('\n') + '\n',
+        details.join('\n') + '\n';
+      return new Response(
+        request.method === 'HEAD' ? null : healthBody,
         {
           status: healthStatus === 'healthy' ? 200 : 503,
           headers: {


### PR DESCRIPTION
## Summary

- Global method filter now allows both GET and HEAD (UptimeRobot sends HEAD by default)
- `/healthz` returns a null body for HEAD requests (correct per HTTP spec)
- 405 response now includes `Allow: GET, HEAD` header

## Details

UptimeRobot HTTP monitors send HEAD requests by default. The global method filter in `src/index.js` rejected all non-GET requests with 405 before they could reach the `/healthz` route, causing UptimeRobot to report the site as down even when the worker was healthy.

No change to health check logic or any other routes.

## Test plan

- [ ] Confirm a GET request to `/healthz` returns 200 with body intact
- [ ] Confirm a HEAD request to `/healthz` returns 200 with no body and correct headers
- [ ] Confirm a POST/PUT/DELETE to any route returns 405 with `Allow: GET, HEAD` header
- [ ] Verify UptimeRobot monitor stops reporting false failures after deploy

https://claude.ai/code/session_018gmgjoaWYf2BBmgEBG1HMC

---
_Generated by [Claude Code](https://claude.ai/code/session_018gmgjoaWYf2BBmgEBG1HMC)_