### PR TITLE
Add severity-matched border-bottom to forecast alert banners

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -115,7 +115,7 @@ const ICON_SIZE_SM   = 26;   // forecast rows + hourly strip icons
 
 // Cache TTLs (seconds)
 const CACHE_SECONDS        =  300;   // page cache + meta-refresh interval
-const CACHE_VERSION        =   13;   // increment to invalidate all cached pages
+const CACHE_VERSION        =   14;   // increment to invalidate all cached pages
 const NWS_CONDITIONS_TTL   =  300;   // current observations (station updates ~hourly)
 const NWS_GRIDDATA_TTL     =  300;   // apparent temperature from gridpoints
 const NWS_FORECAST_TTL     = 1800;   // daily + hourly forecast (~4 updates/day)
@@ -1135,6 +1135,16 @@ function alertSeverityClass(severity) {
   return 'alert-advisory';
 }
 
+// Returns the border color constant matching a given NWS alert severity.
+// Mirrors the border-left colors already applied by the alert CSS classes.
+function alertSeverityBorderColor(severity) {
+  if (!severity) return ALERT_ADVISORY_BORDER;
+  var s = severity.toLowerCase();
+  if (s === 'extreme' || s === 'severe') return ALERT_WARNING_BORDER;
+  if (s === 'moderate')                  return ALERT_WATCH_BORDER;
+  return ALERT_ADVISORY_BORDER;
+}
+
 // Returns the forecast badge severity class for CSS styling.
 function badgeSeverityClass(severity) {
   const s = (severity || '').toLowerCase();
@@ -1639,12 +1649,14 @@ function buildForecastBandHtml(daily, alerts, bandWidth, scale) {
         var onsetDate = toLocalDateStr(onset);
         var endsDate  = toLocalDateStr(ends);
         if (onsetDate <= day.dateStr && endsDate >= day.dateStr) {
-          var cls = alertSeverityClass(p.severity);
+          var cls       = alertSeverityClass(p.severity);
+          var borderClr = alertSeverityBorderColor(p.severity);
           alertBannerHtml =
             '<div class="' + cls + '" style="' +
               'font-size:' + Math.round(18 * scale) + 'px;font-weight:700;' +
               'text-transform:uppercase;letter-spacing:.08em;' +
               'padding:' + Math.round(4 * scale) + 'px ' + Math.round(8 * scale) + 'px;' +
+              'border-bottom:1px solid ' + borderClr + ';' +
               'flex-shrink:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;' +
             '">⚠ ' + escapeHtml(p.event || 'Alert') + '</div>';
           break;
@@ -1739,12 +1751,14 @@ function buildStackedForecastHtml(daily, alerts, panelWidth, scale) {
         var onsetDate = toLocalDateStr(onset);
         var endsDate  = toLocalDateStr(ends);
         if (onsetDate <= day.dateStr && endsDate >= day.dateStr) {
-          var cls = alertSeverityClass(p.severity);
+          var cls       = alertSeverityClass(p.severity);
+          var borderClr = alertSeverityBorderColor(p.severity);
           alertBannerHtml =
             '<div class="' + cls + '" style="' +
               'font-size:' + Math.round(18 * scale) + 'px;font-weight:700;' +
               'text-transform:uppercase;letter-spacing:.08em;' +
               'padding:' + Math.round(4 * scale) + 'px ' + Math.round(8 * scale) + 'px;' +
+              'border-bottom:1px solid ' + borderClr + ';' +
               'flex-shrink:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;' +
             '">⚠ ' + escapeHtml(p.event || 'Alert') + '</div>';
           break;


### PR DESCRIPTION
## Summary

- Adds `alertSeverityBorderColor` helper function (mirrors `alertSeverityClass`) that returns the matching border color constant (`ALERT_WARNING_BORDER`, `ALERT_WATCH_BORDER`, or `ALERT_ADVISORY_BORDER`) for a given NWS alert severity
- Applies `border-bottom: 1px solid <color>` to the alert banner `<div>` in both `buildForecastBandHtml` and `buildStackedForecastHtml`, so the bottom edge reinforces the existing left-border severity color
- Bumps `CACHE_VERSION` 13 → 14 to invalidate cached pages

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMfguFWWMn9LPPYmLgKHgv)_