### PR TITLE
Add gradient divider between forecast band and hourly strip; fix precip label clipping

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -133,7 +133,7 @@ const ICON_SIZE_SM   = 26;   // forecast rows + hourly strip icons
 
 // Cache TTLs (seconds)
 const CACHE_SECONDS        =  300;   // page cache + meta-refresh interval
-const CACHE_VERSION        =   15;   // increment to invalidate all cached pages
+const CACHE_VERSION        =   16;   // increment to invalidate all cached pages
 const NWS_CONDITIONS_TTL   =  300;   // current observations (station updates ~hourly)
 const NWS_GRIDDATA_TTL     =  300;   // apparent temperature from gridpoints
 const NWS_FORECAST_TTL     = 1800;   // daily + hourly forecast (~4 updates/day)
@@ -144,6 +144,8 @@ const RAINVIEWER_TTL       =   60;   // RainViewer frame list (new frames every 
 // Hourly strip height (px) for wide/full layouts.
 const HOURLY_HEIGHT        = { full: 180, wide: 150 };
 const FORECAST_BAND_HEIGHT = { full: 135, wide: 110 };
+// Height in px of the gradient divider rule between the forecast band and hourly strip.
+const DIVIDER_HEIGHT = 4;
 
 // Alert banner configuration.
 // ALERT_BANNER_HEIGHT_PX: vertical pixels reserved per active alert banner.
@@ -1320,6 +1322,7 @@ function renderFullPage(wx, apparent, daily, todayHiLo, hourly, alerts, aqi,
       '<div class="radar-panel">' + radarHtml + '</div>' +
     '</div>' +
     '<div class="forecast-band">' + forecastHtml + '</div>' +
+    '<div class="fc-hourly-divider"></div>' +
     '<div class="hourly-strip">'  + hourlyHtml   + '</div>';
 
   const headExtra =
@@ -1908,8 +1911,8 @@ function buildHourlyStripHtml(hourly, width, stripH, scale) {
       'color:' + TEXT_TERTIARY + ';font-size:12px;">Hourly data unavailable</div>';
   }
 
-  var timeLabelH = Math.round(stripH * 0.26);
-  var curveH     = Math.round(stripH * 0.48);
+  var timeLabelH = Math.round(stripH * 0.24);
+  var curveH     = Math.round(stripH * 0.42);
   var bottomH    = stripH - timeLabelH - curveH;
   var colW       = width / hourly.length;
 
@@ -2291,7 +2294,9 @@ function baseStyles(width, height, useSolidBg) {
     '.fc-card-stacked{flex-shrink:0;}' +
     '.fc-card-stacked:last-child{border-bottom:none;}' +
 
-    '.hourly-strip{flex-shrink:0;display:flex;flex-direction:column;border-top:1px solid ' + BORDER_STRONG + ';background:' + CARD_BASE + ';overflow:hidden;}' +
+    '.fc-hourly-divider{flex-shrink:0;height:' + DIVIDER_HEIGHT + 'px;' +
+      'background:linear-gradient(90deg,' + ACCENT_COLOR + ' 0%,rgba(0,0,0,0) 60%);}' +
+    '.hourly-strip{flex-shrink:0;display:flex;flex-direction:column;background:' + CARD_BASE + ';overflow:hidden;}' +
     '.hour-labels{flex-shrink:0;display:flex;flex-direction:row;}' +
     '.hour-label-col{flex:1;display:flex;align-items:center;justify-content:center;text-transform:uppercase;color:' + TEXT_SECONDARY + ';}' +
     '.hour-bottom{flex-shrink:0;display:flex;flex-direction:row;}' +
@@ -2307,7 +2312,7 @@ function buildFullPageStyles(width, height, condWidth, stripH, forecastBandH, sc
     'body{display:flex;flex-direction:column;}' +
     '.cond-panel{width:' + condWidth + 'px;flex-shrink:0;}' +
     '.forecast-band{height:' + forecastBandH + 'px;}' +
-    '.hourly-strip{height:' + stripH + 'px;}'
+    '.hourly-strip{height:' + (stripH - DIVIDER_HEIGHT) + 'px;}'
   );
 }
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Gradient divider** (`DIVIDER_HEIGHT = 4px`) inserted between the forecast band and hourly strip in `renderFullPage`. Replaces the old `border-top` on `.hourly-strip` with a left-to-right gradient (`ACCENT_COLOR` → transparent) via a new `.fc-hourly-divider` div and CSS class. The divider is subtracted from the `.hourly-strip` height override in `buildFullPageStyles` so total layout height is unchanged. The divider is not added to `renderConditionsOnly` (split/tri has no hourly strip).
- **Precipitation label clipping fix**: `timeLabelH` reduced from 26% to 24% and `curveH` from 48% to 42% of `stripH` in `buildHourlyStripHtml`, giving `bottomH` ~34% of the strip (up from ~26%) so condition icons, precip bars, and labels have enough vertical room.
- **Cache version** bumped from 15 to 16 to immediately invalidate all cached pages.

## Test plan

- [ ] `wide` layout: confirm gradient divider appears between forecast band and hourly strip; no border-top visible on strip
- [ ] `full` layout: same as above
- [ ] `split` and `tri` layouts: confirm no divider element appears (conditions-only and radar-only views)
- [ ] Hourly strip: confirm precipitation percentage labels are no longer clipped at the bottom
- [ ] No regressions to alert banners, forecast band, radar panel, or conditions panel layout

https://claude.ai/code/session_01JrFNA2kN8czwZZkgSdA6JV
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrFNA2kN8czwZZkgSdA6JV)_