### PR TITLE
Rearrange conditions stats grid: add DEW POINT tile, remove UV INDEX

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -133,7 +133,7 @@ const ICON_SIZE_SM   = 26;   // forecast rows + hourly strip icons
 
 // Cache TTLs (seconds)
 const CACHE_SECONDS        =  300;   // page cache + meta-refresh interval
-const CACHE_VERSION        =   16;   // increment to invalidate all cached pages
+const CACHE_VERSION        =   17;   // increment to invalidate all cached pages
 const NWS_CONDITIONS_TTL   =  300;   // current observations (station updates ~hourly)
 const NWS_GRIDDATA_TTL     =  300;   // apparent temperature from gridpoints
 const NWS_FORECAST_TTL     = 1800;   // daily + hourly forecast (~4 updates/day)
@@ -1600,9 +1600,8 @@ function buildConditionsPanelHtml(wx, apparent, todayHiLo, alerts, aqi, sunTimes
     ? [(windDir || ''), (windSpd !== null ? windSpd + ' mph' : '')].filter(Boolean).join(' ')
     : '--';
 
-  var humVal = wx.humidity !== null
-    ? wx.humidity + '%' + (wx.dewpoint !== null ? ' \xB7 Dew Point ' + wx.dewpoint + '\xB0F' : '')
-    : '--';
+  var humVal = wx.humidity !== null ? wx.humidity + '%' : '--';
+  var dewVal = wx.dewpoint !== null ? wx.dewpoint + '\xB0F' : '--';
 
   var pressVal = wx.pressure   !== null ? wx.pressure.toFixed(2) + ' inHg' : '--';
   var visVal   = wx.visibility !== null ? wx.visibility + ' mi'   : '--';
@@ -1613,12 +1612,6 @@ function buildConditionsPanelHtml(wx, apparent, todayHiLo, alerts, aqi, sunTimes
       escapeHtml(String(wx.windGust) + ' mph') + '</span>'
     : '<span style="color:' + TEXT_PRIMARY + ';font-size:' + statValFont + 'px;">' +
       'None</span>';
-
-  var uvInner = uvIndex !== null
-    ? '<span style="color:' + TEXT_PRIMARY + ';font-size:' + statValFont + 'px;font-weight:700;' +
-      'white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">' +
-      escapeHtml(String(uvIndex) + ' \xB7 ' + getUvCategory(uvIndex)) + '</span>'
-    : '<span style="color:' + TEXT_PRIMARY + ';font-size:' + statValFont + 'px;font-weight:700;">--</span>';
 
   function statCell(label, value) {
     return (
@@ -1644,8 +1637,8 @@ function buildConditionsPanelHtml(wx, apparent, todayHiLo, alerts, aqi, sunTimes
       statCell('HUMIDITY',   humVal)   +
       statCell('PRESSURE',   pressVal) +
       statCellRaw('WIND GUST',  gustInner) +
+      statCell('DEW POINT',  dewVal)   +
       statCell('VISIBILITY', visVal)   +
-      statCellRaw('UV INDEX', uvInner) +
     '</div>';
 
   var forecastLabel =


### PR DESCRIPTION
## Summary

- Humidity tile now shows humidity % only (dew point suffix removed)
- New standalone DEW POINT tile added in position 5 (between WIND GUST and VISIBILITY)
- UV INDEX tile removed from the grid (UV helper functions are untouched)
- `CACHE_VERSION` incremented to 17 to invalidate all cached pages

## Grid layout (before → after)

| | Col 1 | Col 2 | Col 3 |
|---|---|---|---|
| **Row 1** | WIND SPEED | HUMIDITY | PRESSURE |
| **Row 2 (before)** | WIND GUST | VISIBILITY | UV INDEX |
| **Row 2 (after)** | WIND GUST | DEW POINT | VISIBILITY |

## Test plan
- [ ] Verify humidity tile shows only `XX%` with no dew point suffix
- [ ] Verify DEW POINT tile appears between WIND GUST and VISIBILITY
- [ ] Verify UV INDEX tile is gone from the conditions panel
- [ ] Verify UV-related functions (`getUvIndex`, `getUvCategory`) still exist in the file
- [ ] Verify cache busts correctly with the new version (v17)

https://claude.ai/code/session_01MPRGjMb8EtweVsmxuVgUPC

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPRGjMb8EtweVsmxuVgUPC)_